### PR TITLE
remove warnings 

### DIFF
--- a/C14 Device/00 - Orientation/Hello World/UIDevice-Orientation.m
+++ b/C14 Device/00 - Orientation/Hello World/UIDevice-Orientation.m
@@ -27,7 +27,7 @@ CGFloat device_angle;
 	
 }
 
-- (CGFloat)orientationAngle
+- (float)orientationAngle
 {
 #if TARGET_IPHONE_SIMULATOR
 	switch (self.orientation)
@@ -78,7 +78,7 @@ CGFloat device_angle;
 #pragma mark relative orientation
 
 // Thanks Jonah Williams
-- (CGFloat)orientationAngleRelativeToOrientation:(UIDeviceOrientation)someOrientation
+- (float)orientationAngleRelativeToOrientation:(UIDeviceOrientation)someOrientation
 {
  	CGFloat dOrientation = 0.0f;
 	switch (someOrientation)


### PR DESCRIPTION
remove warnings

---

warning: conflicting return type in implementation of 'orientationAngleRelativeToOrientation:': 'float' vs 'CGFloat' (aka 'double')
